### PR TITLE
Configurable BalanceManager

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,6 +7,9 @@
   "package_slug": "{{ cookiecutter.author_org_slug }}_{{ cookiecutter.engine_name_slug }}",
   "author_name": "PolySwarm Developer",
   "author_email": "polyswarm_dev@example.com",
+  "min_balance": "100000000",
+  "increment_balance": "100000000",
+  "max_balance": "false",
   "platform": ["docker-linux", "windows"],
   "has_backend": ["false", "true"],
   "aws_account_for_ami": "001122334455"

--- a/{{ cookiecutter.project_slug }}/docker/test-integration.yml
+++ b/{{ cookiecutter.project_slug }}/docker/test-integration.yml
@@ -1,5 +1,17 @@
 version: '3.4'
 services:
+  balancemanager:
+    image: "polyswarm/polyswarm-client"
+    environment:
+      - PYTHONUNBUFFERED=1
+      - KEYFILE=docker/microengine_keyfile
+      - PASSWORD=password
+    command:
+    - "balancemanager"
+    - "maintain"
+    - "100000000"
+    - "100000000"
+
   {% if cookiecutter.has_backend == "true" %}
   {{ cookiecutter.engine_name_slug }}backend:
     image: "{{ cookiecutter.project_slug }}-backend"

--- a/{{ cookiecutter.project_slug }}/docker/test-integration.yml
+++ b/{{ cookiecutter.project_slug }}/docker/test-integration.yml
@@ -9,8 +9,11 @@ services:
     command:
     - "balancemanager"
     - "maintain"
-    - "100000000"
-    - "100000000"
+    - "%{cookiecutter.min_balance}"
+    - "%{cookiecutter.increment_balance}"
+  {% if cookiecutter.max_balance != "false" %}
+    - "%{cookiecutter.max_balance}"
+  {% endif %}
 
   {% if cookiecutter.has_backend == "true" %}
   {{ cookiecutter.engine_name_slug }}backend:

--- a/{{ cookiecutter.project_slug }}/packer/installengine.ps1
+++ b/{{ cookiecutter.project_slug }}/packer/installengine.ps1
@@ -11,6 +11,10 @@ $ErrorActionPreference = "stop"
 &"pip" install @(Get-ChildItem -Recurse -Filter *.whl)
 
 [System.Environment]::SetEnvironmentVariable('POLYSWARM_ENGINE', '{{ cookiecutter.engine_name_slug }}', 'machine')
+
+# Balancemanager also accepts a 'maximum' parameter
+nssm set balancemanager AppParameters "--minimum 10000000 --refill-amount 10000000"
+
 nssm install microengine c:\Python35\Scripts\microengine.exe """--backend {{ cookiecutter.package_slug }}"""
 nssm set microengine AppDirectory C:\{{ cookiecutter.engine_name }}
 nssm set microengine AppExit Default Restart

--- a/{{ cookiecutter.project_slug }}/packer/installengine.ps1
+++ b/{{ cookiecutter.project_slug }}/packer/installengine.ps1
@@ -17,7 +17,13 @@ nssm set worker AppParameters "--log WARN"
 nssm set worker Start SERVICE_DEMAND_START
 
 # These two parameters are the 'minimum balance' and 'refill amount' that balancemanager will maintain.
-nssm set balancemanager AppParameters "10000000 10000000"
+nssm set balancemanager AppParameters "%{cookiecutter.min_balance}"
+nssm set balancemanager AppParameters "%{cookiecutter.increment_balance}"
+
+{% if cookiecutter.max_balance != "false" %}
+nssm set balancemanager AppParameters "%{cookiecutter.max_balance}"
+{% endif %}
+
 
 nssm install microengine c:\Python35\Scripts\microengine.exe """--backend {{ cookiecutter.package_slug }}"""
 nssm set microengine AppDirectory C:\{{ cookiecutter.engine_name }}

--- a/{{ cookiecutter.project_slug }}/packer/installengine.ps1
+++ b/{{ cookiecutter.project_slug }}/packer/installengine.ps1
@@ -14,6 +14,7 @@ $ErrorActionPreference = "stop"
 
 # You can configure all polyswarm service's logging here
 nssm set worker AppParameters "--log WARN"
+nssm set worker Start SERVICE_DEMAND_START
 
 # Balancemanager also accepts a 'maximum' parameter
 nssm set balancemanager AppParameters "--minimum 10000000 --refill-amount 10000000"

--- a/{{ cookiecutter.project_slug }}/packer/installengine.ps1
+++ b/{{ cookiecutter.project_slug }}/packer/installengine.ps1
@@ -12,6 +12,9 @@ $ErrorActionPreference = "stop"
 
 [System.Environment]::SetEnvironmentVariable('POLYSWARM_ENGINE', '{{ cookiecutter.engine_name_slug }}', 'machine')
 
+# You can configure all polyswarm service's logging here
+nssm set worker AppParameters "--log WARN"
+
 # Balancemanager also accepts a 'maximum' parameter
 nssm set balancemanager AppParameters "--minimum 10000000 --refill-amount 10000000"
 

--- a/{{ cookiecutter.project_slug }}/packer/installengine.ps1
+++ b/{{ cookiecutter.project_slug }}/packer/installengine.ps1
@@ -16,8 +16,8 @@ $ErrorActionPreference = "stop"
 nssm set worker AppParameters "--log WARN"
 nssm set worker Start SERVICE_DEMAND_START
 
-# Balancemanager also accepts a 'maximum' parameter
-nssm set balancemanager AppParameters "--minimum 10000000 --refill-amount 10000000"
+# These two parameters are the 'minimum balance' and 'refill amount' that balancemanager will maintain.
+nssm set balancemanager AppParameters "10000000 10000000"
 
 nssm install microengine c:\Python35\Scripts\microengine.exe """--backend {{ cookiecutter.package_slug }}"""
 nssm set microengine AppDirectory C:\{{ cookiecutter.engine_name }}


### PR DESCRIPTION
This adds `balancemanager` to the Docker and Windows setup. 

This needs a review to see if it addresses the changes in mind.

I've added `balancemanager` configuration parameters to `installengine.ps1` after Nick mentioned that _"our docs say that we only support AMI's with our windows engine template, so I think having this `installengine.ps1` is appropriate."_

@mrtizmoatwork and @aarongooch 