### PR TITLE
Allow sub module importing by using find_packages

### DIFF
--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='{{ cookiecutter.package_slug }}',
@@ -13,7 +13,7 @@ setup(
         'polyswarm-client'
     ],
     include_package_data=True,
-    packages=['{{ cookiecutter.package_slug }}'],
+    packages=find_packages(),
     package_dir={
         '{{ cookiecutter.package_slug }}': '{{ cookiecutter.package_slug }}',
     },


### PR DESCRIPTION
Without find_packages, only the base package is importable. If you have a submodule within your base package, it will probably work if you run it locally or run the unit tests, but when worker executes it in the integration tests, you'll get an import error.