### PR TITLE
Change event loop scope

### DIFF
--- a/{{ cookiecutter.project_slug }}/tests/test_{{ cookiecutter.participant_name_slug }}.py
+++ b/{{ cookiecutter.project_slug }}/tests/test_{{ cookiecutter.participant_name_slug }}.py
@@ -16,7 +16,7 @@ from {{ cookiecutter.package_slug }} import Scanner
 from polyswarmartifact import ArtifactType
 
 
-@pytest.yield_fixture()
+@pytest.yield_fixture('session')
 def event_loop():
     """
     To enable Windows engines to support subprocesses in asyncio, they need to use the ProactorEventLoop.
@@ -28,9 +28,10 @@ def event_loop():
 
     :return: event loop object
     """
-    loop = asyncio.get_event_loop()
     if sys.platform == 'win32':
         loop = asyncio.ProactorEventLoop()
+    else:
+        loop = asyncio.get_event_loop()
     yield loop
     loop.close()
 


### PR DESCRIPTION
Scope for the fixture "event loop" should be "session", otherwise it's not possible to have multiple test scenarios in a single file, given that "event loop" will be destroyed after the first test has been executed.