### PR TITLE
Add lifecycle test for `setup()` and `teardown()`

### DIFF
--- a/{{ cookiecutter.project_slug }}/tests/test_{{ cookiecutter.participant_name_slug }}.py
+++ b/{{ cookiecutter.project_slug }}/tests/test_{{ cookiecutter.participant_name_slug }}.py
@@ -47,40 +47,40 @@ async def test_scan_random_mal_not():
 {% endif %}
     """
     scanner = Scanner()
-    await scanner.setup()
+    async with scanner:
 {% if cookiecutter.microengine_arbiter__supports_scanning_files == "true" %}
-    ###
-    ### File artifacts
-    ###
+        ###
+        ### File artifacts
+        ###
 
-    for t in [True, False]:
-        mal_md, mal_content = DummyMalwareRepoClient()\
-                              .get_random_file(malicious_filter=t)
-        result = await scanner.scan(guid='nocare',
-                                    artifact_type=ArtifactType.FILE,
-                                    content=ArtifactType.FILE.decode_content(mal_content),
-                                    metadata=None,
-                                    chain='home')
-        assert result.bit
-        assert result.verdict == t
+        for t in [True, False]:
+            mal_md, mal_content = DummyMalwareRepoClient()\
+                                  .get_random_file(malicious_filter=t)
+            result = await scanner.scan(guid='nocare',
+                                        artifact_type=ArtifactType.FILE,
+                                        content=ArtifactType.FILE.decode_content(mal_content),
+                                        metadata=None,
+                                        chain='home')
+            assert result.bit
+            assert result.verdict == t
 {% endif -%}
 
 {% if cookiecutter.microengine_arbiter__supports_scanning_urls == "true" %}
-    ###
-    ### URL artifacts
-    ###
+        ###
+        ### URL artifacts
+        ###
 
-    # Expect malicious
-    url = b'http://iuqerfsodp9ifjaposdfjhgosurijfaewrwergwea.com'
-    result = await scanner.scan('nocare', ArtifactType.URL,
-                                ArtifactType.URL.decode_content(url), None, 'home')
-    assert result.verdict
+        # Expect malicious
+        url = b'http://iuqerfsodp9ifjaposdfjhgosurijfaewrwergwea.com'
+        result = await scanner.scan('nocare', ArtifactType.URL,
+                                    ArtifactType.URL.decode_content(url), None, 'home')
+        assert result.verdict
 
-    # Except benign
-    url = b'https://google.com'
-    result = await scanner.scan('nocare', ArtifactType.URL,
-                                ArtifactType.URL.decode_content(url), None, 'home')
-    assert not result.verdict
+        # Except benign
+        url = b'https://google.com'
+        result = await scanner.scan('nocare', ArtifactType.URL,
+                                    ArtifactType.URL.decode_content(url), None, 'home')
+        assert not result.verdict
 
 {%- endif -%}
 

--- a/{{ cookiecutter.project_slug }}/tests/test_{{ cookiecutter.participant_name_slug }}.py
+++ b/{{ cookiecutter.project_slug }}/tests/test_{{ cookiecutter.participant_name_slug }}.py
@@ -84,6 +84,15 @@ async def test_scan_random_mal_not():
 
 {%- endif -%}
 
+@pytest.mark.asyncio
+async def test_setup_teardown_multiple_times():
+    scanner = Scanner()
+    await scanner.setup()
+    await scanner.setup()
+    await scanner.teardown()
+    await scanner.teardown()
+    await scanner.setup()
+
 {%- endif -%}
 
 {% if cookiecutter.participant_type == "ambassador" %}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.package_slug }}/{{cookiecutter.participant_name_slug}}.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.package_slug }}/{{cookiecutter.participant_name_slug}}.py
@@ -100,6 +100,15 @@ class Scanner(AbstractScanner):
         """
         return await self.{{ cookiecutter.participant_name_slug }}.setup()
 
+    async def teardown(self):
+        """
+        Override this method to do any cleanup when the scanner is being shut down.
+
+        This can be called multiple times, due to exception handling restarting the worker/microengine/arbiter
+        There is an expectation that calling `setup()` again will put the AbstractScanner implementation back into working order
+        """
+        await self.{{ cookiecutter.participant_name_slug }}.teardown()
+
     {% if cookiecutter.microengine_arbiter__scan_mode == "async" -%}
     async def scan_async(self, guid, artifact_type, content, metadata, chain):
     {% elif cookiecutter.microengine_arbiter__scan_mode == "sync" -%}
@@ -165,6 +174,15 @@ class {{ cookiecutter.participant_name_slug|title }}:
         # If your participant requires time to, e.g. connect to an external service before it can process requests,
         # check for the availability of the service here. Return True when ready, False if there's an error.
         return True
+
+    async def teardown(self):
+        """
+        Override this method to implement custom teardown logic.
+        """
+        # CUSTOMIZE_HERE
+        # If your participant leaves long running connections, or uses other long running resources, clean them up here
+        # Be aware, setup may be called after teardown due to polyswarm-client's backoff logic
+        pass
 
     {% if cookiecutter.microengine_arbiter__supports_scanning_files == "true" -%}
     {% if cookiecutter.microengine_arbiter__scan_mode == "async" -%}


### PR DESCRIPTION
These functions can be called multiple times in a row, and are expected to work.

The same scanner will be reused after recovering from an unexpected error, so `setup()` can be called again after `teardown()`
This tests calls the lifecycle functions multiple times and only passes if there are no errors